### PR TITLE
Updated to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,7 @@ readme = "README.md"
 keywords = ["dazeus", "irc"]
 license = "MIT"
 
-[lib]
-name = "dazeus"
-path = "src/lib.rs"
-
-[dependencies.rustc-serialize]
-version = "0.3"
-
-[dependencies.unix_socket]
-version = "0.5"
-
-[dependencies.log]
-version = "0.4"
+[dependencies]
+rustc-serialize = "0.3"
+unix_socket = "0.5"
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dazeus"
 version = "0.4.0"
+edition = "2018"
 authors = ["Ruben Nijveld <ruben@gewooniets.nl>"]
 description = "Dazeus IRC bot bindings for rust"
 documentation = "http://dazeus.github.io/dazeus-rs/dazeus/index.html"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,6 @@
 use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::net::TcpStream;
+use std::str::FromStr;
 use unix_socket::UnixStream;
 
 /// A connection enum that encapsulates TCP and Unix sockets.
@@ -28,11 +29,15 @@ impl Connection {
             },
         }
     }
+}
+
+impl FromStr for Connection {
+    type Err = Error;
 
     /// Takes a string in the format type:connection_str and tries to connect
     /// to that location. Returns the connection inside an enum that can be used
     /// inside DaZeus directly.
-    pub fn from_str(connection_str: &str) -> Result<Connection> {
+    fn from_str(connection_str: &str) -> Result<Self> {
         let splits = connection_str.splitn(2, ':').collect::<Vec<_>>();
         if splits.len() == 2 && splits[0] == "unix" {
             Ok(Connection::Unix(UnixStream::connect(splits[1])?))

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -35,9 +35,9 @@ impl Connection {
     pub fn from_str(connection_str: &str) -> Result<Connection> {
         let splits = connection_str.splitn(2, ':').collect::<Vec<_>>();
         if splits.len() == 2 && splits[0] == "unix" {
-            Ok(Connection::Unix(try!(UnixStream::connect(splits[1]))))
+            Ok(Connection::Unix(UnixStream::connect(splits[1])?))
         } else if splits.len() == 2 && splits[0] == "tcp" {
-            Ok(Connection::Tcp(try!(TcpStream::connect(splits[1]))))
+            Ok(Connection::Tcp(TcpStream::connect(splits[1])?))
         } else {
             Err(Error::new(ErrorKind::InvalidInput, "Unknown connection type"))
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,6 @@
-use std::io::{Read, Write, Result, Error, ErrorKind};
-use unix_socket::UnixStream;
+use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::net::TcpStream;
+use unix_socket::UnixStream;
 
 /// A connection enum that encapsulates TCP and Unix sockets.
 ///
@@ -11,7 +11,7 @@ pub enum Connection {
     /// A Unix domain socket, as implemented by the `unix_socket` crate.
     Unix(UnixStream),
     /// A TCP stream, as implemented by `std::net::TcpStream`.
-    Tcp(TcpStream)
+    Tcp(TcpStream),
 }
 
 impl Connection {
@@ -20,12 +20,12 @@ impl Connection {
         match *self {
             Connection::Unix(ref stream) => match stream.try_clone() {
                 Ok(cloned) => Ok(Connection::Unix(cloned)),
-                Err(e) => Err(e)
+                Err(e) => Err(e),
             },
             Connection::Tcp(ref stream) => match stream.try_clone() {
                 Ok(cloned) => Ok(Connection::Tcp(cloned)),
-                Err(e) => Err(e)
-            }
+                Err(e) => Err(e),
+            },
         }
     }
 
@@ -39,7 +39,10 @@ impl Connection {
         } else if splits.len() == 2 && splits[0] == "tcp" {
             Ok(Connection::Tcp(TcpStream::connect(splits[1])?))
         } else {
-            Err(Error::new(ErrorKind::InvalidInput, "Unknown connection type"))
+            Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Unknown connection type",
+            ))
         }
     }
 }

--- a/src/dazeus.rs
+++ b/src/dazeus.rs
@@ -1,16 +1,16 @@
-use std::io::{Read, Write};
+use super::error::{Error, ReceiveError};
 use super::event::{Event, EventType};
 use super::handler::{Handler, Message};
-use super::listener::{ListenerHandle, Listener};
+use super::listener::{Listener, ListenerHandle};
 use super::request::{ConfigGroup, Request};
 use super::response::Response;
 use super::scope::Scope;
-use super::error::{ReceiveError, Error};
 use std::cell::RefCell;
+use std::io::{Read, Write};
 
 struct ResponseQueue {
     pub responses: Vec<Response>,
-    pub expecting: u64
+    pub expecting: u64,
 }
 
 /// The base DaZeus struct.
@@ -21,10 +21,13 @@ pub struct DaZeus<'a, T> {
     handler: RefCell<Handler<T>>,
     listeners: Vec<Listener<'a>>,
     current_handle: u64,
-    queue: RefCell<ResponseQueue>
+    queue: RefCell<ResponseQueue>,
 }
 
-impl<'a, T> DaZeus<'a, T> where T: Read + Write {
+impl<'a, T> DaZeus<'a, T>
+where
+    T: Read + Write,
+{
     /// Create a new instance of DaZeus from the given connection.
     pub fn new(conn: T) -> DaZeus<'a, T> {
         DaZeus {
@@ -46,7 +49,9 @@ impl<'a, T> DaZeus<'a, T> where T: Read + Write {
     }
 
     fn next_response(&self) -> Result<Response, Error> {
-        { self.queue.borrow_mut().expecting += 1; }
+        {
+            self.queue.borrow_mut().expecting += 1;
+        }
         loop {
             {
                 let mut queue = self.queue.borrow_mut();
@@ -67,7 +72,7 @@ impl<'a, T> DaZeus<'a, T> where T: Read + Write {
                     } else {
                         queue.responses.push(r);
                     }
-                },
+                }
             }
         }
     }
@@ -78,7 +83,7 @@ impl<'a, T> DaZeus<'a, T> where T: Read + Write {
             Message::Event(e) => {
                 self.handle_event(e.clone());
                 Ok(e)
-            },
+            }
             Message::Response(_) => Err(Error::ReceiveError(ReceiveError::new())),
         }
     }
@@ -101,7 +106,8 @@ impl<'a, T> DaZeus<'a, T> where T: Read + Write {
 
     /// Subscribe to an event type and call the callback function every time such an event occurs.
     pub fn subscribe<F>(&mut self, event: EventType, callback: F) -> (ListenerHandle, Response)
-        where F: FnMut(Event, &dyn DaZeusClient) + 'a
+    where
+        F: FnMut(Event, &dyn DaZeusClient) + 'a,
     {
         let request = match event {
             EventType::Command(ref cmd) => Request::SubscribeCommand(cmd.clone(), None),
@@ -118,7 +124,8 @@ impl<'a, T> DaZeus<'a, T> where T: Read + Write {
 
     /// Subscribe to a command and call the callback function every time such a command occurs.
     pub fn subscribe_command<F>(&mut self, command: &str, callback: F) -> (ListenerHandle, Response)
-        where F: FnMut(Event, &dyn DaZeusClient) + 'a
+    where
+        F: FnMut(Event, &dyn DaZeusClient) + 'a,
     {
         self.subscribe(EventType::Command(command.to_string()), callback)
     }
@@ -250,10 +257,15 @@ pub trait DaZeusClient<'a> {
     fn reply_with_action(&self, event: &Event, message: &str) -> Response;
 }
 
-impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
+impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T>
+where
+    T: Read + Write,
+{
     /// Try to send a request to DaZeus
     fn try_send(&self, request: Request) -> Result<Response, Error> {
-        { self.handler.borrow_mut().write(request)? };
+        {
+            self.handler.borrow_mut().write(request)?
+        };
         self.next_response()
     }
 
@@ -319,7 +331,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
         self.send(Request::Message(
             network.to_string(),
             channel.to_string(),
-            message.to_string()
+            message.to_string(),
         ))
     }
 
@@ -328,7 +340,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
         self.send(Request::Notice(
             network.to_string(),
             channel.to_string(),
-            message.to_string()
+            message.to_string(),
         ))
     }
 
@@ -337,7 +349,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
         self.send(Request::Ctcp(
             network.to_string(),
             channel.to_string(),
-            message.to_string()
+            message.to_string(),
         ))
     }
 
@@ -346,7 +358,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
         self.send(Request::CtcpReply(
             network.to_string(),
             channel.to_string(),
-            message.to_string()
+            message.to_string(),
         ))
     }
 
@@ -355,7 +367,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
         self.send(Request::Action(
             network.to_string(),
             channel.to_string(),
-            message.to_string()
+            message.to_string(),
         ))
     }
 
@@ -430,7 +442,11 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
 
     /// Set a property to be stored in the bot database.
     fn set_property(&self, name: &str, value: &str, scope: Scope) -> Response {
-        self.send(Request::SetProperty(name.to_string(), value.to_string(), scope))
+        self.send(Request::SetProperty(
+            name.to_string(),
+            value.to_string(),
+            scope,
+        ))
     }
 
     /// Remove a property stored in the bot database.
@@ -452,7 +468,11 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
     ///
     /// Will return the default if it was not.
     fn has_permission(&self, permission: &str, default: bool, scope: Scope) -> Response {
-        self.send(Request::HasPermission(permission.to_string(), default, scope))
+        self.send(Request::HasPermission(
+            permission.to_string(),
+            default,
+            scope,
+        ))
     }
 
     /// Remove a set permission from the bot.
@@ -478,7 +498,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
                         self.send(Request::Unsubscribe(EventType::Whois));
                     }
                     return evt;
-                },
+                }
                 _ => (),
             }
         }
@@ -502,7 +522,7 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
                         self.send(Request::Unsubscribe(EventType::Names));
                     }
                     return evt;
-                },
+                }
                 _ => (),
             }
         }
@@ -518,11 +538,11 @@ impl<'a, T> DaZeusClient<'a> for DaZeus<'a, T> where T: Read + Write {
             if channel == nick {
                 self.message(network, user, message)
             } else if highlight {
-    let msg = format!("{}: {}", user, message);
-    self.message(network, channel, &msg[..])
-} else {
-    self.message(network, channel, message)
-}
+                let msg = format!("{}: {}", user, message);
+                self.message(network, channel, &msg[..])
+            } else {
+                self.message(network, channel, message)
+            }
         } else {
             Response::for_fail("Not an event to reply to")
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,21 @@
-use std::io::Error as IoError;
 use rustc_serialize::json::ParserError as JsonParserError;
-use std::str::Utf8Error;
-use std::fmt::{Display, Formatter};
 use std::fmt::Error as FmtError;
+use std::fmt::{Display, Formatter};
+use std::io::Error as IoError;
+use std::str::Utf8Error;
 
 /// Error returned when the passed Json did not have the required structure.
 #[derive(Debug, Clone, PartialEq)]
-pub struct InvalidJsonError { message: String }
+pub struct InvalidJsonError {
+    message: String,
+}
 
 impl InvalidJsonError {
     /// Create a new error instance.
     pub fn new(message: &str) -> InvalidJsonError {
-        InvalidJsonError { message: message.to_string() }
+        InvalidJsonError {
+            message: message.to_string(),
+        }
     }
 }
 
@@ -19,7 +23,9 @@ impl InvalidJsonError {
 ///
 /// This may occur if an event is provided by DaZeus which is unknown by this implementation.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParseEventTypeError { _priv: () }
+pub struct ParseEventTypeError {
+    _priv: (),
+}
 
 impl ParseEventTypeError {
     /// Create a new error instance.
@@ -30,7 +36,9 @@ impl ParseEventTypeError {
 
 /// Error returned when a string could not be parsed as a `ConfigGroup`.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParseConfigGroupError { _priv: () }
+pub struct ParseConfigGroupError {
+    _priv: (),
+}
 
 impl ParseConfigGroupError {
     /// Create a new error instance.
@@ -41,7 +49,9 @@ impl ParseConfigGroupError {
 
 /// Error when an unexpected or invalid response was received from DaZeus
 #[derive(Debug, Clone, PartialEq)]
-pub struct ReceiveError { _priv: () }
+pub struct ReceiveError {
+    _priv: (),
+}
 
 impl ReceiveError {
     pub fn new() -> ReceiveError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use std::io::Error as IoError;
-use serialize::json::ParserError as JsonParserError;
+use crate::serialize::json::ParserError as JsonParserError;
 use std::str::Utf8Error;
 use std::fmt::{Display, Formatter};
 use std::fmt::Error as FmtError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use std::io::Error as IoError;
-use crate::serialize::json::ParserError as JsonParserError;
+use rustc_serialize::json::ParserError as JsonParserError;
 use std::str::Utf8Error;
 use std::fmt::{Display, Formatter};
 use std::fmt::Error as FmtError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::io::Error as IoError;
 use std::str::Utf8Error;
 
 /// Error returned when the passed Json did not have the required structure.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct InvalidJsonError {
     message: String,
 }
@@ -22,7 +22,7 @@ impl InvalidJsonError {
 /// Error returned when a string could not be parsed as an `EventType`.
 ///
 /// This may occur if an event is provided by DaZeus which is unknown by this implementation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ParseEventTypeError {
     _priv: (),
 }
@@ -35,7 +35,7 @@ impl ParseEventTypeError {
 }
 
 /// Error returned when a string could not be parsed as a `ConfigGroup`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ParseConfigGroupError {
     _priv: (),
 }
@@ -48,7 +48,7 @@ impl ParseConfigGroupError {
 }
 
 /// Error when an unexpected or invalid response was received from DaZeus
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ReceiveError {
     _priv: (),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use crate::serialize::json::Json;
+use rustc_serialize::json::Json;
 use super::error::{ParseEventTypeError, InvalidJsonError};
 use std::ops::Index;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -204,7 +204,7 @@ impl Event {
     }
 
     /// Create a new event based on the properties extracted from the Json.
-    fn create_event(evt: &str, params: &Vec<Json>) -> Result<Event, InvalidJsonError> {
+    fn create_event(evt: &str, params: &[Json]) -> Result<Event, InvalidJsonError> {
         if evt == "COMMAND" {
             if params.len() >= 4 && params[3].is_string() {
                 let cmd = params[3].as_string().unwrap().to_string();
@@ -224,7 +224,7 @@ impl Event {
     }
 
     /// Extract string parameters from an array of `Json::String` objects.
-    fn param_strs(params: &Vec<Json>) -> Vec<String> {
+    fn param_strs(params: &[Json]) -> Vec<String> {
         let mut strs = Vec::new();
         for param in params {
             if param.is_string() {
@@ -235,7 +235,7 @@ impl Event {
     }
 
     /// Retrieve a parameter from the list of parameters contained in the event.
-    pub fn param<'a>(&'a self, idx: usize) -> &'a str {
+    pub fn param(&self, idx: usize) -> &str {
         &self.params[idx][..]
     }
 
@@ -243,12 +243,17 @@ impl Event {
     pub fn len(&self) -> usize {
         self.params.len()
     }
+
+    /// Do we have any parameters?
+    pub fn is_empty(&self) -> bool {
+        self.params.is_empty()
+    }
 }
 
 impl<'b> Index<usize> for Event {
     type Output = str;
 
-    fn index<'a>(&'a self, index: usize) -> &'a str {
+    fn index(&self, index: usize) -> &str {
         self.param(index)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use serialize::json::Json;
+use crate::serialize::json::Json;
 use super::error::{ParseEventTypeError, InvalidJsonError};
 use std::ops::Index;
 
@@ -179,7 +179,7 @@ impl Event {
     /// ));
     /// ```
     pub fn new(event: EventType, params: Vec<String>) -> Event {
-        Event { event: event, params: params }
+        Event { event, params }
     }
 
     /// Create a new event based on a Json data object.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,5 @@
 use std::io::{Read, Write};
-use serialize::json::{ToJson, Json};
+use crate::serialize::json::{ToJson, Json};
 use std::str::{from_utf8};
 use super::response::Response;
 use super::event::{Event, is_event_json};
@@ -19,7 +19,7 @@ pub struct Handler<T> {
 
 impl<T> Handler<T> where T: Read + Write {
     pub fn new(socket: T) -> Handler<T> {
-        Handler { socket: socket, buffer: Vec::new() }
+        Handler { socket, buffer: Vec::new() }
     }
 
     pub fn read(&mut self) -> Result<Message, Error> {
@@ -28,14 +28,14 @@ impl<T> Handler<T> where T: Read + Write {
                 return self.make_message(offset, len);
             }
 
-            try!(self.retrieve_from_socket());
+            self.retrieve_from_socket()?;
         }
     }
 
     /// Retrieve new data from the socket
     fn retrieve_from_socket(&mut self) -> Result<(), Error> {
         let mut buf = [0; 1024];
-        let bytes = try!(self.socket.read(&mut buf));
+        let bytes = self.socket.read(&mut buf)?;
         for b in buf[..bytes].iter() {
             self.buffer.push(*b);
         }
@@ -84,14 +84,14 @@ impl<T> Handler<T> where T: Read + Write {
         // first make sure we have a correct internal state
         self.buffer = self.buffer[offset+length..].to_owned(); // iter().collect();
 
-        let json = try!(try!(json_try));
+        let json = json_try??;
 
         if is_event_json(&json) {
-            let evt = try!(Event::from_json(&json));
+            let evt = Event::from_json(&json)?;
             debug!("Valid event received: {}", json);
             Ok(Message::Event(evt))
         } else {
-            let resp = try!(Response::from_json(&json));
+            let resp = Response::from_json(&json)?;
             debug!("Valid response received: {}", json);
             Ok(Message::Response(resp))
         }
@@ -102,8 +102,8 @@ impl<T> Handler<T> where T: Read + Write {
         debug!("Sending message: {}", encoded);
 
         let bytes = encoded.as_bytes();
-        try!(self.socket.write_all(format!("{}", bytes.len()).as_bytes()));
-        try!(self.socket.write_all(bytes));
+        self.socket.write_all(format!("{}", bytes.len()).as_bytes())?;
+        self.socket.write_all(bytes)?;
         Ok(())
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
-use crate::serialize::json::{ToJson, Json};
+use rustc_serialize::json::{ToJson, Json};
+use log::debug;
 use std::str::{from_utf8};
 use super::response::Response;
 use super::event::{Event, is_event_json};

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,12 +1,12 @@
-use std::io::{Read, Write};
-use rustc_serialize::json::{ToJson, Json};
-use log::debug;
-use std::str::{from_utf8};
-use super::response::Response;
-use super::event::{Event, is_event_json};
-use super::request::Request;
 use super::error::Error;
+use super::event::{is_event_json, Event};
+use super::request::Request;
+use super::response::Response;
+use log::debug;
+use rustc_serialize::json::{Json, ToJson};
 use std::borrow::ToOwned;
+use std::io::{Read, Write};
+use std::str::from_utf8;
 
 pub enum Message {
     Response(Response),
@@ -18,9 +18,15 @@ pub struct Handler<T> {
     buffer: Vec<u8>,
 }
 
-impl<T> Handler<T> where T: Read + Write {
+impl<T> Handler<T>
+where
+    T: Read + Write,
+{
     pub fn new(socket: T) -> Handler<T> {
-        Handler { socket, buffer: Vec::new() }
+        Handler {
+            socket,
+            buffer: Vec::new(),
+        }
     }
 
     pub fn read(&mut self) -> Result<Message, Error> {
@@ -64,7 +70,10 @@ impl<T> Handler<T> where T: Read + Write {
         }
 
         if message_len > 0 && self.buffer.len() >= offset + message_len {
-            debug!("Found message in buffer starting at {} with length {}", offset, message_len);
+            debug!(
+                "Found message in buffer starting at {} with length {}",
+                offset, message_len
+            );
             Some((offset, message_len))
         } else {
             debug!("Found no complete message in buffer");
@@ -83,7 +92,7 @@ impl<T> Handler<T> where T: Read + Write {
         };
 
         // first make sure we have a correct internal state
-        self.buffer = self.buffer[offset+length..].to_owned(); // iter().collect();
+        self.buffer = self.buffer[offset + length..].to_owned(); // iter().collect();
 
         let json = json_try??;
 
@@ -103,7 +112,8 @@ impl<T> Handler<T> where T: Read + Write {
         debug!("Sending message: {}", encoded);
 
         let bytes = encoded.as_bytes();
-        self.socket.write_all(format!("{}", bytes.len()).as_bytes())?;
+        self.socket
+            .write_all(format!("{}", bytes.len()).as_bytes())?;
         self.socket.write_all(bytes)?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! Creating a new connection can now be done using the following basic snippet:
 //!
 //! ```no_run
+//! use std::str::FromStr;
 //! use dazeus::{Connection,DaZeus};
 //! let socket = "unix:/tmp/dazeus.sock";
 //! let dazeus = DaZeus::new(Connection::from_str(socket).unwrap());
@@ -32,6 +33,7 @@
 //!
 //! ```no_run
 //! # use dazeus::*;
+//! # use std::str::FromStr;
 //! let socket = "unix:/tmp/dazeus.sock";
 //! let mut dazeus = DaZeus::new(Connection::from_str(socket).unwrap());
 //! dazeus.subscribe(EventType::PrivMsg, |evt, dazeus| {
@@ -47,6 +49,7 @@
 //!
 //! ```no_run
 //! # use dazeus::*;
+//! # use std::str::FromStr;
 //! let socket = "unix:/tmp/dazeus.sock";
 //! let dazeus = DaZeus::new(Connection::from_str(socket).unwrap());
 //! dazeus.join("local", "#test");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@ pub use self::scope::*;
 
 mod connection;
 mod dazeus;
+mod error;
 mod event;
 mod handler;
 mod listener;
 mod request;
 mod response;
 mod scope;
-mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,6 @@
 //! dazeus.join("local", "#test");
 //! ```
 
-#[macro_use]
-extern crate log;
-extern crate rustc_serialize as serialize;
-extern crate unix_socket;
-
 pub use self::connection::*;
 pub use self::dazeus::*;
 pub use self::error::*;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,9 +1,9 @@
-use super::event::{Event, EventType};
 use super::dazeus::{DaZeus, DaZeusClient};
-use std::fmt::{Debug, Error, Formatter};
+use super::event::{Event, EventType};
 use std::cell::RefCell;
-use std::ops::DerefMut;
+use std::fmt::{Debug, Error, Formatter};
 use std::io::{Read, Write};
+use std::ops::DerefMut;
 
 /// An identifier for unsubscribing an event listener.
 pub type ListenerHandle = u64;
@@ -14,7 +14,7 @@ pub struct Listener<'a> {
     callback: RefCell<Box<dyn FnMut(Event, &dyn DaZeusClient) + 'a>>,
 }
 
-impl<'a> PartialEq for Listener<'a>{
+impl<'a> PartialEq for Listener<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.handle == other.handle
     }
@@ -22,15 +22,24 @@ impl<'a> PartialEq for Listener<'a>{
 
 impl<'a> Debug for Listener<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "Listener {{ event: {:?}, handle: {:?} callback: FnMut(Event) }}", self.event, self.handle)
+        write!(
+            f,
+            "Listener {{ event: {:?}, handle: {:?} callback: FnMut(Event) }}",
+            self.event, self.handle
+        )
     }
 }
 
 impl<'a> Listener<'a> {
     pub fn new<F>(handle: ListenerHandle, event_type: EventType, listener: F) -> Listener<'a>
-        where F: FnMut(Event, &dyn DaZeusClient) + 'a
+    where
+        F: FnMut(Event, &dyn DaZeusClient) + 'a,
     {
-        Listener { event: event_type, handle, callback: RefCell::new(Box::new(listener)) }
+        Listener {
+            event: event_type,
+            handle,
+            callback: RefCell::new(Box::new(listener)),
+        }
     }
 
     pub fn call<T: Read + Write>(&self, event: Event, dazeus: &DaZeus<T>) {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -11,7 +11,7 @@ pub type ListenerHandle = u64;
 pub struct Listener<'a> {
     pub event: EventType,
     pub handle: ListenerHandle,
-    callback: RefCell<Box<FnMut(Event, &DaZeusClient) + 'a>>,
+    callback: RefCell<Box<dyn FnMut(Event, &dyn DaZeusClient) + 'a>>,
 }
 
 impl<'a> PartialEq for Listener<'a>{
@@ -28,15 +28,15 @@ impl<'a> Debug for Listener<'a> {
 
 impl<'a> Listener<'a> {
     pub fn new<F>(handle: ListenerHandle, event_type: EventType, listener: F) -> Listener<'a>
-        where F: FnMut(Event, &DaZeusClient) + 'a
+        where F: FnMut(Event, &dyn DaZeusClient) + 'a
     {
-        Listener { event: event_type, handle: handle, callback: RefCell::new(Box::new(listener)) }
+        Listener { event: event_type, handle, callback: RefCell::new(Box::new(listener)) }
     }
 
     pub fn call<T: Read + Write>(&self, event: Event, dazeus: &DaZeus<T>) {
         let mut fbox = self.callback.borrow_mut();
         let func = fbox.deref_mut();
-        func(event, dazeus as &DaZeusClient);
+        func(event, dazeus as &dyn DaZeusClient);
     }
 
     pub fn has_handle(&self, handle: ListenerHandle) -> bool {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -11,6 +11,7 @@ pub type ListenerHandle = u64;
 pub struct Listener<'a> {
     pub event: EventType,
     pub handle: ListenerHandle,
+    #[allow(clippy::type_complexity)]
     callback: RefCell<Box<dyn FnMut(Event, &dyn DaZeusClient) + 'a>>,
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,9 @@
-use super::scope::Scope;
-use rustc_serialize::json::{Json, ToJson, Object, Array};
-use super::event::EventType;
-use std::string::ToString;
-use std::str::FromStr;
 use super::error::ParseConfigGroupError;
+use super::event::EventType;
+use super::scope::Scope;
+use rustc_serialize::json::{Array, Json, Object, ToJson};
+use std::str::FromStr;
+use std::string::ToString;
 
 /// The version of the DaZeus plugin communication protocol that these bindings understand.
 pub const PROTOCOL_VERSION: &str = "1";
@@ -53,7 +53,7 @@ impl FromStr for ConfigGroup {
         match &s.to_ascii_lowercase()[..] {
             "plugin" => Ok(ConfigGroup::Plugin),
             "core" => Ok(ConfigGroup::Core),
-            _ => Err(ParseConfigGroupError::new())
+            _ => Err(ParseConfigGroupError::new()),
         }
     }
 }
@@ -336,7 +336,9 @@ impl Request {
 
     fn get_action_type(&self) -> String {
         let s = match *self {
-            Request::Networks | Request::Channels(_) | Request::Nick(_) | Request::Config(_, _) => "get",
+            Request::Networks | Request::Channels(_) | Request::Nick(_) | Request::Config(_, _) => {
+                "get"
+            }
             _ => "do",
         };
 
@@ -352,34 +354,37 @@ impl ToJson for Request {
 
         let mut params = Array::new();
 
-        macro_rules! push_str { ($x: expr) => ( params.push(Json::String($x.clone())) ) }
+        macro_rules! push_str {
+            ($x: expr) => {
+                params.push(Json::String($x.clone()))
+            };
+        }
 
         match *self {
             Request::Subscribe(EventType::Command(ref cmd)) => {
                 push_str!(cmd);
-            },
+            }
             Request::Unsubscribe(EventType::Command(_)) => {
                 // we can't actually unsubscribe a command
                 panic!("Cannot unsubscribe from command");
-            },
+            }
             Request::Subscribe(ref evt) => {
                 push_str!(evt.to_string());
-            },
+            }
             Request::Unsubscribe(ref evt) => {
                 push_str!(evt.to_string());
-            },
+            }
             Request::SubscribeCommand(ref cmd, Some(ref network)) => {
                 push_str!(cmd);
                 push_str!(network);
-            },
+            }
             Request::SubscribeCommand(ref cmd, None) => {
                 push_str!(cmd);
-            },
+            }
             Request::Networks => (),
-            Request::Channels(ref network)
-            | Request::Nick(ref network) => {
+            Request::Channels(ref network) | Request::Nick(ref network) => {
                 push_str!(network);
-            },
+            }
             Request::Message(ref network, ref channel, ref message)
             | Request::Notice(ref network, ref channel, ref message)
             | Request::Ctcp(ref network, ref channel, ref message)
@@ -388,40 +393,40 @@ impl ToJson for Request {
                 push_str!(network);
                 push_str!(channel);
                 push_str!(message);
-            },
+            }
             Request::Names(ref network, ref channel)
             | Request::Join(ref network, ref channel)
             | Request::Part(ref network, ref channel) => {
                 push_str!(network);
                 push_str!(channel);
-            },
+            }
             Request::Whois(ref network, ref user) => {
                 push_str!(network);
                 push_str!(user);
-            },
+            }
             Request::Handshake(ref name, ref version, Some(ref config_name)) => {
                 push_str!(name);
                 push_str!(version);
                 push_str!(PROTOCOL_VERSION.to_string());
                 push_str!(config_name);
-            },
+            }
             Request::Handshake(ref name, ref version, None) => {
                 push_str!(name);
                 push_str!(version);
                 push_str!(PROTOCOL_VERSION.to_string());
                 push_str!(name);
-            },
+            }
             Request::Config(ref key, ref ctype) => {
                 push_str!(ctype.to_string());
                 push_str!(key);
-            },
+            }
             Request::GetProperty(ref property, ref scope) => {
                 push_str!("get".to_string());
                 push_str!(property);
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::SetProperty(ref property, ref value, ref scope) => {
                 push_str!("set".to_string());
                 push_str!(property);
@@ -429,21 +434,21 @@ impl ToJson for Request {
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::UnsetProperty(ref property, ref scope) => {
                 push_str!("unset".to_string());
                 push_str!(property);
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::PropertyKeys(ref prefix, ref scope) => {
                 push_str!("keys".to_string());
                 push_str!(prefix);
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::SetPermission(ref permission, ref default, ref scope) => {
                 push_str!("set".to_string());
                 push_str!(permission);
@@ -451,7 +456,7 @@ impl ToJson for Request {
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::HasPermission(ref permission, ref default, ref scope) => {
                 push_str!("get".to_string());
                 push_str!(permission);
@@ -459,14 +464,14 @@ impl ToJson for Request {
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
             Request::UnsetPermission(ref permission, ref scope) => {
                 push_str!("unset".to_string());
                 push_str!(permission);
                 if !scope.is_any() {
                     obj.insert("scope".to_string(), scope.to_json());
                 }
-            },
+            }
         }
 
         if !params.is_empty() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,5 @@
 use super::scope::Scope;
-use crate::serialize::json::{Json, ToJson, Object, Array};
+use rustc_serialize::json::{Json, ToJson, Object, Array};
 use super::event::EventType;
 use std::string::ToString;
 use std::str::FromStr;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,12 +1,12 @@
 use super::scope::Scope;
-use serialize::json::{Json, ToJson, Object, Array};
+use crate::serialize::json::{Json, ToJson, Object, Array};
 use super::event::EventType;
 use std::string::ToString;
 use std::str::FromStr;
 use super::error::ParseConfigGroupError;
 
 /// The version of the DaZeus plugin communication protocol that these bindings understand.
-pub const PROTOCOL_VERSION: &'static str = "1";
+pub const PROTOCOL_VERSION: &str = "1";
 
 /// A `String` for the target IRC network.
 pub type Network = String;
@@ -469,7 +469,7 @@ impl ToJson for Request {
             },
         }
 
-        if params.len() > 0 {
+        if !params.is_empty() {
             obj.insert("params".to_string(), Json::Array(params));
         }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -82,10 +82,7 @@ impl Response {
 
     /// Returns whether or not a property with the given name exists.
     pub fn has(&self, prop: &str) -> bool {
-        match self.get_str(prop) {
-            Some(_) => true,
-            None => false,
-        }
+        self.get_str(prop).is_some()
     }
 
     /// Check whether a Response contains a `success` property and whether it was true.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
-use crate::serialize::json::Json;
-use crate::serialize::json::Object;
+use rustc_serialize::json::Json;
+use rustc_serialize::json::Object;
 use super::error::InvalidJsonError;
 
 /// The response from a command send to the DaZeus server.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
-use serialize::json::Json;
-use serialize::json::Object;
+use crate::serialize::json::Json;
+use crate::serialize::json::Object;
 use super::error::InvalidJsonError;
 
 /// The response from a command send to the DaZeus server.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,11 +1,11 @@
+use super::error::InvalidJsonError;
 use rustc_serialize::json::Json;
 use rustc_serialize::json::Object;
-use super::error::InvalidJsonError;
 
 /// The response from a command send to the DaZeus server.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Response {
-    data: Json
+    data: Json,
 }
 
 impl Response {
@@ -18,7 +18,9 @@ impl Response {
         obj.insert("success".to_string(), Json::Boolean(false));
         obj.insert("reason".to_string(), Json::String(msg.to_string()));
 
-        Response { data: Json::Object(obj) }
+        Response {
+            data: Json::Object(obj),
+        }
     }
 
     /// Create a new response based upon a successful operation.
@@ -28,7 +30,9 @@ impl Response {
         let mut obj = Object::new();
         obj.insert("success".to_string(), Json::Boolean(true));
 
-        Response { data: Json::Object(obj) }
+        Response {
+            data: Json::Object(obj),
+        }
     }
 
     /// Create a new response based on a Json object.
@@ -52,9 +56,7 @@ impl Response {
     /// Returns `Some(data)` if the property exists, or `None` if the property doesn't exist.
     pub fn get<'a>(&'a self, prop: &'a str) -> Option<&'a Json> {
         match self.data {
-            Json::Object(ref obj) => {
-                obj.get(prop)
-            },
+            Json::Object(ref obj) => obj.get(prop),
             _ => None,
         }
     }
@@ -82,7 +84,7 @@ impl Response {
     pub fn has(&self, prop: &str) -> bool {
         match self.get_str(prop) {
             Some(_) => true,
-            None => false
+            None => false,
         }
     }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,4 +1,4 @@
-use rustc_serialize::json::{ToJson, Json, Array};
+use rustc_serialize::json::{Array, Json, ToJson};
 
 /// A scope for retrieving permissions and properties.
 ///
@@ -30,7 +30,11 @@ pub struct Scope {
 impl Scope {
     /// Construct a new scope with the specified limitations for network, sender and receiver
     pub fn new(network: Option<String>, sender: Option<String>, receiver: Option<String>) -> Scope {
-        Scope { network, sender, receiver }
+        Scope {
+            network,
+            sender,
+            receiver,
+        }
     }
 
     /// Scope to everyone and anything
@@ -55,7 +59,11 @@ impl Scope {
 
     /// Scope to a specific receiver and channel (typically a user in a channel)
     pub fn to(network: &str, sender: &str, receiver: &str) -> Scope {
-        Scope::new(Some(network.to_string()), Some(sender.to_string()), Some(receiver.to_string()))
+        Scope::new(
+            Some(network.to_string()),
+            Some(sender.to_string()),
+            Some(receiver.to_string()),
+        )
     }
 
     /// Checks whether the scope is set to be applied to everything.

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,4 +1,4 @@
-use crate::serialize::json::{ToJson, Json, Array};
+use rustc_serialize::json::{ToJson, Json, Array};
 
 /// A scope for retrieving permissions and properties.
 ///

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,4 +1,4 @@
-use serialize::json::{ToJson, Json, Array};
+use crate::serialize::json::{ToJson, Json, Array};
 
 /// A scope for retrieving permissions and properties.
 ///
@@ -30,7 +30,7 @@ pub struct Scope {
 impl Scope {
     /// Construct a new scope with the specified limitations for network, sender and receiver
     pub fn new(network: Option<String>, sender: Option<String>, receiver: Option<String>) -> Scope {
-        Scope { network: network, sender: sender, receiver: receiver }
+        Scope { network, sender, receiver }
     }
 
     /// Scope to everyone and anything


### PR DESCRIPTION
Did:

* `cargo fix`
* `cargo fix --clippy` 
* replaced `try` by `?`
* Got rid of `extern crate`
* Cleaned up `cargo.toml`
* Ran `cargo fmt`

It's probably easiest to review the set of commits not including the cargo fmt.